### PR TITLE
Dipole moment addition

### DIFF
--- a/dev/fluids/Cyclopentane.json
+++ b/dev/fluids/Cyclopentane.json
@@ -548,6 +548,8 @@
       "T_critical_units": "K", 
       "acentric": 0.1521, 
       "acentric_units": "-", 
+      "dipole_moment_D": 0.0,
+      "dipole_moment_D_units": "Debye",
       "kappa": 0.0, 
       "kappa_units": "-", 
       "molar_mass": 0.0701329, 

--- a/dev/fluids/D4.json
+++ b/dev/fluids/D4.json
@@ -437,6 +437,8 @@
       "Ttriple_units": "K", 
       "acentric": 0.592, 
       "acentric_units": "-", 
+      "dipole_moment": 1.091e+00,  
+      "dipole_moment_units": "Debye",  
       "alpha0": [
         {
           "a1": 29.18574340067077, 

--- a/dev/fluids/Isopentane.json
+++ b/dev/fluids/Isopentane.json
@@ -376,7 +376,9 @@
       "ipentane", 
       "R601a", 
       "ISOPENTANE", 
-      "IPENTANE"
+      "IPENTANE",
+      "methylbutane",
+      "2-methylbutane"
     ], 
     "CAS": "78-78-4", 
     "CHEMSPIDER_ID": 6308, 
@@ -532,6 +534,8 @@
       "T_critical_units": "K", 
       "acentric": 0.2274, 
       "acentric_units": "-", 
+      "dipole_moment_D": 0.1,
+      "dipole_moment_D_units": "Debye",
       "kappa": 0.0, 
       "kappa_units": "-", 
       "molar_mass": 0.07214878, 

--- a/dev/fluids/MDM.json
+++ b/dev/fluids/MDM.json
@@ -436,6 +436,8 @@
       "Ttriple_units": "K", 
       "acentric": 0.5297, 
       "acentric_units": "-", 
+      "dipole_moment": 8.001e-01,  
+      "dipole_moment_units": "Debye",  
       "alpha0": [
         {
           "a1": -7.468857958439935, 

--- a/dev/fluids/MM.json
+++ b/dev/fluids/MM.json
@@ -238,6 +238,8 @@
       "Ttriple_units": "K", 
       "acentric": 0.418, 
       "acentric_units": "-", 
+      "dipole_moment": 7.801e-01,  
+      "dipole_moment_units": "Debye",  
       "alpha0": [
         {
           "a1": 0, 

--- a/dev/fluids/R11.json
+++ b/dev/fluids/R11.json
@@ -238,6 +238,8 @@
       "Ttriple_units": "K", 
       "acentric": 0.1887506482528083, 
       "acentric_units": "-", 
+      "dipole_moment": 5.001e-01,  
+      "dipole_moment_units": "Debye",  
       "alpha0": [
         {
           "a1": 0, 

--- a/dev/fluids/R123.json
+++ b/dev/fluids/R123.json
@@ -517,6 +517,8 @@
       "Ttriple_units": "K", 
       "acentric": 0.2819224970363519, 
       "acentric_units": "-", 
+      "dipole_moment": 1.356e+00,  
+      "dipole_moment_units": "Debye",  
       "alpha0": [
         {
           "a1": 0, 

--- a/dev/fluids/R1234ze(E).json
+++ b/dev/fluids/R1234ze(E).json
@@ -460,6 +460,8 @@
       "Ttriple_units": "K", 
       "acentric": 0.313, 
       "acentric_units": "-", 
+      "dipole_moment":  -1,  
+      "dipole_moment_units": "Debye",  
       "alpha0": [
         {
           "a1": 0, 

--- a/dev/fluids/R152A.json
+++ b/dev/fluids/R152A.json
@@ -238,6 +238,8 @@
       "Ttriple_units": "K", 
       "acentric": 0.275217114532099, 
       "acentric_units": "-", 
+      "dipole_moment": 2.262e+00,  
+      "dipole_moment_units": "Debye",  
       "alpha0": [
         {
           "a1": 0, 

--- a/dev/fluids/R245fa.json
+++ b/dev/fluids/R245fa.json
@@ -242,6 +242,8 @@
       "Ttriple_units": "K", 
       "acentric": 0.3776, 
       "acentric_units": "-", 
+      "dipole_moment": 1.549e+00,  
+      "dipole_moment_units": "Debye",  
       "alpha0": [
         {
           "a1": -13.4283638514, 

--- a/include/CoolPropFluid.h
+++ b/include/CoolPropFluid.h
@@ -277,7 +277,7 @@ struct ViscosityECSVariables{
     std::vector<CoolPropDbl> psi_a, psi_t;
 };
 struct ViscosityChungData{
-    CoolPropDbl rhomolar_critical, acentric, T_critical, molar_mass, dipole_moment;
+    CoolPropDbl rhomolar_critical, acentric, T_critical, molar_mass, dipole_moment_D;
 };
 
 class TransportPropertyData

--- a/src/Backends/Helmholtz/Fluids/FluidLibrary.h
+++ b/src/Backends/Helmholtz/Fluids/FluidLibrary.h
@@ -313,7 +313,18 @@ protected:
         EOS.R_u = cpjson::get_double(EOS_json,"gas_constant");
         EOS.molar_mass = cpjson::get_double(EOS_json,"molar_mass");
         EOS.acentric = cpjson::get_double(EOS_json,"acentric");
-        EOS.dipole_moment = cpjson::get_double(EOS_json,"dipole_moment");
+        double dpm = cpjson::get_double(EOS_json,"dipole_moment");
+        std::string dpm_units = cpjson::get_string(EOS_json, "dipole_moment_units");
+        if ((dpm_units == "Debye") || (dpm_units == "debye")) {
+            EOS.dipole_moment = dpm * 3.33564e-30;  // Convert units from Debye to SI (C*m)
+        }
+        else if (dpm_units == "C*m") {
+            EOS.dipole_moment = dpm;                // dipole_moment already in SI (C*m) units
+        }
+        else {
+            throw ValueError(format("Invalid dipole moment units [%s]. Valid units are : Debye or C*m\n", dpm_units));
+        }
+
 
         EOS.pseudo_pure = cpjson::get_bool(EOS_json, "pseudo_pure");
         EOS.limits.Tmax = cpjson::get_double(EOS_json, "T_max");
@@ -654,7 +665,7 @@ protected:
         fluid.transport.viscosity_Chung.rhomolar_critical = cpjson::get_double(viscosity, "rhomolar_critical");
         fluid.transport.viscosity_Chung.T_critical = cpjson::get_double(viscosity, "T_critical");
         fluid.transport.viscosity_Chung.molar_mass = cpjson::get_double(viscosity, "molar_mass");
-        fluid.transport.viscosity_Chung.dipole_moment = cpjson::get_double(viscosity, "dipole_moment");
+        fluid.transport.viscosity_Chung.dipole_moment_D = cpjson::get_double(viscosity, "dipole_moment_D");
         fluid.transport.viscosity_Chung.acentric = cpjson::get_double(viscosity, "acentric");
         fluid.transport.viscosity_using_Chung = true;
     }

--- a/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
+++ b/src/Backends/Helmholtz/HelmholtzEOSMixtureBackend.cpp
@@ -478,19 +478,7 @@ CoolPropDbl HelmholtzEOSMixtureBackend::calc_dipole_moment(void)
 {
     if (is_pure_or_pseudopure){
         if (components[0].EOS().dipole_moment >= 0){
-            double dipoleMoment = 0;
-            if (components[0].EOS().dipole_moment_units == "Debye"){
-                double debyeToSI = 3.33564e-30;
-                dipoleMoment = components[0].EOS().dipole_moment * debyeToSI;
-            }
-            else if (components[0].EOS().dipole_moment_units == "C*m"){
-                dipoleMoment = components[0].EOS().dipole_moment;
-            }
-            else{
-                throw ValueError("Invalid dipole moment units. Valid values are: Debye, and C*m ");
-            }
-
-            return dipoleMoment;
+            return components[0].EOS().dipole_moment;  // units of C*m
         }
         else{
             throw ValueError("dipole moment not defined in fluid JSON file");

--- a/src/Backends/Helmholtz/TransportRoutines.cpp
+++ b/src/Backends/Helmholtz/TransportRoutines.cpp
@@ -658,7 +658,7 @@ CoolPropDbl TransportRoutines::viscosity_Chung(HelmholtzEOSMixtureBackend &HEOS)
         double acentric = data.acentric; // [-]
         double M_gmol = data.molar_mass*1000.0; // [g/mol]
         double Tc = data.T_critical; // [K]
-        double mu_D = data.dipole_moment; // [D]
+        double mu_D = data.dipole_moment_D; // [D]
         double kappa = 0;
 
         double mu_r = 131.3*mu_D/sqrt(Vc_cm3mol*Tc); // [-]


### PR DESCRIPTION
### Description of the Change

Several items updated:

1. Restored the dipole_moment_D values in the JSON files and operations within CoolProp.  This parameter is expected in the Chung Viscosity model and cannot be removed.
2. Moved the unit checks to FluidLibrary.h where the JSON file is read.  This eliminates the need to store the unit string indefinitely.  It also converts (if needed) and stores the dipole moment values in SI, eliminating the need to convert the value every time calc_dipole_moment() is called.

### Verification Process

Tested on both Python and Mathcad.  PropsSI and Props1SI are returning the correct dipole moment values from the JSON files and in the correct SI units.
