### PR TITLE
Clean up JSON fluid files and add source reference field dipole_moment_refs

### DIFF
--- a/dev/fluids/1-Butene.json
+++ b/dev/fluids/1-Butene.json
@@ -238,8 +238,9 @@
       "Ttriple_units": "K", 
       "acentric": 0.191860647355, 
       "acentric_units": "-",
-      "dipole_moment": 3.598e-01,  
+      "dipole_moment": 3.59e-01,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "https://cccbdb.nist.gov/diplistx.asp",
       "alpha0": [
         {
           "a1": -0.00101126, 

--- a/dev/fluids/Acetone.json
+++ b/dev/fluids/Acetone.json
@@ -240,6 +240,7 @@
       "acentric_units": "-", 
       "dipole_moment": 2.880e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "https://cccbdb.nist.gov/diplistx.asp",
       "alpha0": [
         {
           "a1": -9.4883659997, 

--- a/dev/fluids/Air.json
+++ b/dev/fluids/Air.json
@@ -272,8 +272,8 @@
       "acentric_note": "The acentric factor for pseudo-pure fluids is undefined, but given value is approximate", 
       "acentric_units": "-", 
       "dipole_moment":  -1,  
-      "dipole_note": "The dipole moment for a mixture is undefined", 
       "dipole_moment_units": "Debye",  
+      "dipole_ref": "The dipole moment for mixtures is undefined", 
       "alpha0": [
         {
           "a1": 0, 

--- a/dev/fluids/Ammonia.json
+++ b/dev/fluids/Ammonia.json
@@ -242,6 +242,7 @@
       "acentric_units": "-", 
       "dipole_moment": 1.470e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "https://cccbdb.nist.gov/diplistx.asp",
       "alpha0": [
         {
           "a1": -15.81502, 

--- a/dev/fluids/Argon.json
+++ b/dev/fluids/Argon.json
@@ -261,6 +261,7 @@
       "acentric_units": "-", 
       "dipole_moment": 0.000e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "Monatomic molecule",
       "alpha0": [
         {
           "a1": 8.31666243, 

--- a/dev/fluids/Benzene.json
+++ b/dev/fluids/Benzene.json
@@ -244,6 +244,7 @@
       "acentric_units": "-", 
       "dipole_moment": 0.000e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "Symmetric Molecule; https://cccbdb.nist.gov/diplistx.asp",
       "alpha0": [
         {
           "a1": -0.6740687105, 

--- a/dev/fluids/CarbonDioxide.json
+++ b/dev/fluids/CarbonDioxide.json
@@ -261,6 +261,7 @@
       "acentric_units": "-", 
       "dipole_moment": 0.000e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "https://cccbdb.nist.gov/diplistx.asp",
       "alpha0": [
         {
           "a1": 8.37304456, 

--- a/dev/fluids/CarbonMonoxide.json
+++ b/dev/fluids/CarbonMonoxide.json
@@ -253,8 +253,9 @@
       "Ttriple_units": "K", 
       "acentric": 0.0497, 
       "acentric_units": "-", 
-      "dipole_moment": 1.121e-01,  
+      "dipole_moment": 1.12e-01,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "https://cccbdb.nist.gov/diplistx.asp",
       "alpha0": [
         {
           "a1": -3.3728318564, 

--- a/dev/fluids/CarbonylSulfide.json
+++ b/dev/fluids/CarbonylSulfide.json
@@ -238,8 +238,9 @@
       "Ttriple_units": "K", 
       "acentric": 0.0978, 
       "acentric_units": "-", 
-      "dipole_moment": 7.105e-01,  
+      "dipole_moment": 7.12e-01,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "https://cccbdb.nist.gov/diplistx.asp",
       "alpha0": [
         {
           "a1": -3.6587449805, 

--- a/dev/fluids/CycloHexane.json
+++ b/dev/fluids/CycloHexane.json
@@ -256,6 +256,7 @@
       "acentric_units": "-", 
       "dipole_moment": 0.000e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "Symmetric Molecule",
       "alpha0": [
         {
           "a1": 0.9891140602, 

--- a/dev/fluids/CycloPropane.json
+++ b/dev/fluids/CycloPropane.json
@@ -240,6 +240,7 @@
       "acentric_units": "-", 
       "dipole_moment": 0.000e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "\"The Properties of Gases and Liquids\" 5th edition, Poling, Prausnitz, and O'Connell.",
       "alpha0": [
         {
           "a1": 0, 

--- a/dev/fluids/Cyclopentane.json
+++ b/dev/fluids/Cyclopentane.json
@@ -240,6 +240,7 @@
       "acentric_units": "-", 
       "dipole_moment": 0.000e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "\"The Properties of Gases and Liquids\" 5th edition, Poling, Prausnitz, and O'Connell.",
       "alpha0": [
         {
           "a1": 3.2489131288, 

--- a/dev/fluids/D4.json
+++ b/dev/fluids/D4.json
@@ -240,6 +240,7 @@
       "acentric_units": "-", 
       "dipole_moment": 1.091e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "https://www.gelest.com/product/octamethylcyclotetrasiloxane-98/",
       "alpha0": [
         {
           "_note": "a1 and a2 calculated by IB.  Values in Thol thesis incorrect", 
@@ -439,6 +440,7 @@
       "acentric_units": "-", 
       "dipole_moment": 1.091e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "https://www.gelest.com/product/octamethylcyclotetrasiloxane-98/",
       "alpha0": [
         {
           "a1": 29.18574340067077, 

--- a/dev/fluids/D5.json
+++ b/dev/fluids/D5.json
@@ -240,6 +240,7 @@
       "acentric_units": "-", 
       "dipole_moment": 1.220e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "https://www.gelest.com/product/decamethylcyclopentasiloxane/",
       "alpha0": [
         {
           "a1": -7.87509994783932, 

--- a/dev/fluids/D6.json
+++ b/dev/fluids/D6.json
@@ -240,6 +240,7 @@
       "acentric_units": "-", 
       "dipole_moment": 1.560e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "https://www.gelest.com/product/dodecamethylcyclohexasiloxane/",
       "alpha0": [
         {
           "a1": -7.938561730464921, 

--- a/dev/fluids/Deuterium.json
+++ b/dev/fluids/Deuterium.json
@@ -240,6 +240,7 @@
       "acentric_units": "-", 
       "dipole_moment": 0.000e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "\"The Properties of Gases and Liquids\" 5th edition, Poling, Prausnitz, and O'Connell.",
       "alpha0": [
         {
           "a1": -2.0677351753, 

--- a/dev/fluids/Dichloroethane.json
+++ b/dev/fluids/Dichloroethane.json
@@ -141,6 +141,7 @@
       "acentric_units": "-", 
       "dipole_moment": 1.799e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "\"The Properties of Gases and Liquids\" 5th edition, Poling, Prausnitz, and O'Connell.",
       "alpha0": [
         {
           "a1": 25.029988, 

--- a/dev/fluids/DiethylEther.json
+++ b/dev/fluids/DiethylEther.json
@@ -154,6 +154,7 @@
       "acentric_units": "-", 
       "dipole_moment": 1.310e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "\"The Properties of Gases and Liquids\" 5th edition, Poling, Prausnitz, and O'Connell.",
       "alpha0": [
         {
           "a1": 17.099494, 

--- a/dev/fluids/DimethylCarbonate.json
+++ b/dev/fluids/DimethylCarbonate.json
@@ -238,8 +238,9 @@
       "Ttriple_units": "K", 
       "acentric": 0.346, 
       "acentric_units": "-", 
-      "dipole_moment": 9.294e-01,  
+      "dipole_moment": 9.3e-01,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "http://www.stenutz.eu/chem/solv6.php?name=dimethyl%20carbonate",
       "alpha0": [
         {
           "a1": 4.9916462, 

--- a/dev/fluids/DimethylEther.json
+++ b/dev/fluids/DimethylEther.json
@@ -240,6 +240,7 @@
       "acentric_units": "-", 
       "dipole_moment": 1.300e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "\"The Properties of Gases and Liquids\" 5th edition, Poling, Prausnitz, and O'Connell.",
       "alpha0": [
         {
           "a1": -1.980976, 

--- a/dev/fluids/Ethane.json
+++ b/dev/fluids/Ethane.json
@@ -263,6 +263,7 @@
       "acentric_units": "-", 
       "dipole_moment": 0.000e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "\"The Properties of Gases and Liquids\" 5th edition, Poling, Prausnitz, and O'Connell.",
       "alpha0": [
         {
           "a1": 9.212802589, 

--- a/dev/fluids/Ethanol.json
+++ b/dev/fluids/Ethanol.json
@@ -256,6 +256,7 @@
       "acentric_units": "-", 
       "dipole_moment": 1.700e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "\"The Properties of Gases and Liquids\" 5th edition, Poling, Prausnitz, and O'Connell.",
       "alpha0": [
         {
           "a1": -12.7531, 

--- a/dev/fluids/EthylBenzene.json
+++ b/dev/fluids/EthylBenzene.json
@@ -240,6 +240,7 @@
       "acentric_units": "-", 
       "dipole_moment": 3.999e-01,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "\"The Properties of Gases and Liquids\" 5th edition, Poling, Prausnitz, and O'Connell.",
       "alpha0": [
         {
           "a1": 5.70409, 

--- a/dev/fluids/Ethylene.json
+++ b/dev/fluids/Ethylene.json
@@ -271,6 +271,7 @@
       "acentric_units": "-", 
       "dipole_moment": 0.000e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "\"The Properties of Gases and Liquids\" 5th edition, Poling, Prausnitz, and O'Connell.",
       "alpha0": [
         {
           "a1": 8.68815523, 

--- a/dev/fluids/EthyleneOxide.json
+++ b/dev/fluids/EthyleneOxide.json
@@ -137,6 +137,7 @@
       "acentric_units": "-", 
       "dipole_moment": 1.940e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "Haynes, William M., ed. (2011). CRC Handbook of Chemistry and Physics (92nd ed.). Boca Raton, FL: CRC Press. ISBN 1439855110.",
       "alpha0": [
         {
           "a1": -3.90644775, 

--- a/dev/fluids/Fluorine.json
+++ b/dev/fluids/Fluorine.json
@@ -259,6 +259,7 @@
       "acentric_units": "-", 
       "dipole_moment": 0.000e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "Monatomic; \"The Properties of Gases and Liquids\" 5th edition, Poling, Prausnitz, and O'Connell.",
       "alpha0": [
         {
           "n": [

--- a/dev/fluids/HFE143m.json
+++ b/dev/fluids/HFE143m.json
@@ -229,6 +229,7 @@
       "acentric_units": "-", 
       "dipole_moment": 2.320e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "http://www.ethermo.us/ShowDetail2821.htm",
       "alpha0": [
         {
           "a1": -17.97705674077087, 

--- a/dev/fluids/HeavyWater.json
+++ b/dev/fluids/HeavyWater.json
@@ -150,6 +150,7 @@
       "acentric_units": "-", 
       "dipole_moment": 1.900e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "\"The Properties of Gases and Liquids\" 5th edition, Poling, Prausnitz, and O'Connell.",
       "alpha0": [
         {
           "a1": -8.6739710041, 

--- a/dev/fluids/Helium.json
+++ b/dev/fluids/Helium.json
@@ -259,6 +259,7 @@
       "acentric_units": "-", 
       "dipole_moment": 0.000e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "Monatomic; \"The Properties of Gases and Liquids\" 5th edition, Poling, Prausnitz, and O'Connell.",
       "alpha0": [
         {
           "a1": 0.1871304489697973, 

--- a/dev/fluids/Hydrogen.json
+++ b/dev/fluids/Hydrogen.json
@@ -259,6 +259,7 @@
       "acentric_units": "-", 
       "dipole_moment": 0.000e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "Monatomic; \"The Properties of Gases and Liquids\" 5th edition, Poling, Prausnitz, and O'Connell.",
       "alpha0": [
         {
           "a1": -1.4579856475, 

--- a/dev/fluids/HydrogenChloride.json
+++ b/dev/fluids/HydrogenChloride.json
@@ -135,6 +135,7 @@
       "acentric_units": "-", 
       "dipole_moment": 1.100e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "\"The Properties of Gases and Liquids\" 5th edition, Poling, Prausnitz, and O'Connell.",
       "alpha0": [
         {
           "a1": 7.95672158, 

--- a/dev/fluids/HydrogenSulfide.json
+++ b/dev/fluids/HydrogenSulfide.json
@@ -240,6 +240,7 @@
       "acentric_units": "-", 
       "dipole_moment": 9.000e-01,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "\"The Properties of Gases and Liquids\" 5th edition, Poling, Prausnitz, and O'Connell.",
       "alpha0": [
         {
           "a1": -4.0740770957, 

--- a/dev/fluids/IsoButane.json
+++ b/dev/fluids/IsoButane.json
@@ -259,8 +259,9 @@
       "Ttriple_units": "K", 
       "acentric": 0.183531783208, 
       "acentric_units": "-", 
-      "dipole_moment": 1.000e-01,  
+      "dipole_moment": 0.132,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "NIST; https://cccbdb.nist.gov/diplistx.asp",
       "alpha0": [
         {
           "a1": 11.60865546, 

--- a/dev/fluids/IsoButene.json
+++ b/dev/fluids/IsoButene.json
@@ -240,6 +240,7 @@
       "acentric_units": "-", 
       "dipole_moment": 5.001e-01,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "\"The Properties of Gases and Liquids\" 5th edition, Poling, Prausnitz, and O'Connell.",
       "alpha0": [
         {
           "a1": -0.12737888, 

--- a/dev/fluids/Isohexane.json
+++ b/dev/fluids/Isohexane.json
@@ -240,6 +240,7 @@
       "acentric_units": "-", 
       "dipole_moment": -1,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "\"The Properties of Gases and Liquids\" 5th edition, Poling, Prausnitz, and O'Connell.",
       "alpha0": [
         {
           "a1": 6.9259123919, 

--- a/dev/fluids/Isopentane.json
+++ b/dev/fluids/Isopentane.json
@@ -255,6 +255,7 @@
       "acentric_units": "-", 
       "dipole_moment": 0.11,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "\"The Properties of Gases and Liquids\" 5th edition, Poling, Prausnitz, and O'Connell.",
       "alpha0": [
         {
           "a1": 2.5822330405, 

--- a/dev/fluids/Krypton.json
+++ b/dev/fluids/Krypton.json
@@ -255,6 +255,7 @@
       "acentric_units": "-", 
       "dipole_moment": 0.000e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "Monatomic; \"The Properties of Gases and Liquids\" 5th edition, Poling, Prausnitz, and O'Connell.",
       "alpha0": [
         {
           "a1": -3.7506412806, 

--- a/dev/fluids/MD2M.json
+++ b/dev/fluids/MD2M.json
@@ -240,6 +240,7 @@
       "acentric_units": "-", 
       "dipole_moment": 1.220e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "Commercial Gelest site: https://www.gelest.com/product/decamethyltetrasiloxane/",
       "alpha0": [
         {
           "a1": -7.756334333038524, 

--- a/dev/fluids/MD3M.json
+++ b/dev/fluids/MD3M.json
@@ -240,6 +240,7 @@
       "acentric_units": "-", 
       "dipole_moment":  -1,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "Undefined per: http://www.ethermo.us/ShowDetail91.htm",
       "alpha0": [
         {
           "a1": -7.835183629103501, 

--- a/dev/fluids/MD4M.json
+++ b/dev/fluids/MD4M.json
@@ -240,6 +240,7 @@
       "acentric_units": "-", 
       "dipole_moment":  -1,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "Undefined per: http://www.ethermo.us/ShowDetail92.htm",
       "alpha0": [
         {
           "a1": -8.139550790894862, 

--- a/dev/fluids/MDM.json
+++ b/dev/fluids/MDM.json
@@ -240,6 +240,7 @@
       "acentric_units": "-", 
       "dipole_moment": 8.001e-01,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "Commercial Gelest site: https://www.gelest.com/product/octamethyltrisiloxane/",
       "alpha0": [
         {
           "a1": 117.9946064218, 
@@ -436,8 +437,9 @@
       "Ttriple_units": "K", 
       "acentric": 0.5297, 
       "acentric_units": "-", 
-      "dipole_moment": 8.001e-01,  
+      "dipole_moment": 8.00e-01,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "Commercial Gelest site: https://www.gelest.com/product/octamethyltrisiloxane/",
       "alpha0": [
         {
           "a1": -7.468857958439935, 

--- a/dev/fluids/MM.json
+++ b/dev/fluids/MM.json
@@ -240,6 +240,7 @@
       "acentric_units": "-", 
       "dipole_moment": 7.801e-01,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "Commercial Gelest site: https://www.gelest.com/product/hexamethyldisiloxane-98/",
       "alpha0": [
         {
           "a1": 0, 
@@ -484,8 +485,9 @@
       "Ttriple_units": "K", 
       "acentric": 0.418, 
       "acentric_units": "-", 
-      "dipole_moment": 7.801e-01,  
+      "dipole_moment": 0.78,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "Commercial Gelest site: https://www.gelest.com/product/hexamethyldisiloxane-98/",
       "alpha0": [
         {
           "a1": 8.673203925289393, 

--- a/dev/fluids/Methane.json
+++ b/dev/fluids/Methane.json
@@ -259,6 +259,7 @@
       "acentric_units": "-", 
       "dipole_moment": 0.000e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "\"The Properties of Gases and Liquids\" 5th edition, Poling, Prausnitz, and O'Connell.",
       "alpha0": [
         {
           "a1": 9.91243972, 

--- a/dev/fluids/Methanol.json
+++ b/dev/fluids/Methanol.json
@@ -267,6 +267,7 @@
       "acentric_units": "-", 
       "dipole_moment": 1.700e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "\"The Properties of Gases and Liquids\" 5th edition, Poling, Prausnitz, and O'Connell.",
       "alpha0": [
         {
           "a1": 13.9864114647, 

--- a/dev/fluids/MethylLinoleate.json
+++ b/dev/fluids/MethylLinoleate.json
@@ -240,6 +240,7 @@
       "acentric_units": "-", 
       "dipole_moment":  -1,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "Undefined per: http://www.ethermo.us/ShowDetail100.htm",
       "alpha0": [
         {
           "a1": -1, 

--- a/dev/fluids/MethylLinolenate.json
+++ b/dev/fluids/MethylLinolenate.json
@@ -229,6 +229,7 @@
       "acentric_units": "-", 
       "dipole_moment": 1.540e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "http://www.ethermo.us/ShowDetail101.htm",
       "alpha0": [
         {
           "a1": -1, 

--- a/dev/fluids/MethylOleate.json
+++ b/dev/fluids/MethylOleate.json
@@ -240,6 +240,7 @@
       "acentric_units": "-", 
       "dipole_moment": 1.630e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "http://www.ethermo.us/ShowDetail103.htm",
       "alpha0": [
         {
           "a1": -1, 

--- a/dev/fluids/MethylPalmitate.json
+++ b/dev/fluids/MethylPalmitate.json
@@ -242,6 +242,7 @@
       "acentric_units": "-", 
       "dipole_moment": 1.540e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "http://www.ethermo.us/ShowDetail104.htm",
       "alpha0": [
         {
           "a1": -1, 

--- a/dev/fluids/MethylStearate.json
+++ b/dev/fluids/MethylStearate.json
@@ -242,6 +242,7 @@
       "acentric_units": "-", 
       "dipole_moment": 1.540e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "http://www.ethermo.us/ShowDetail105.htm",
       "alpha0": [
         {
           "a1": -1, 

--- a/dev/fluids/Neon.json
+++ b/dev/fluids/Neon.json
@@ -259,6 +259,7 @@
       "acentric_units": "-", 
       "dipole_moment": 0.000e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "Monatomic; \"The Properties of Gases and Liquids\" 5th edition, Poling, Prausnitz, and O'Connell.",
       "alpha0": [
         {
           "a1": 0, 

--- a/dev/fluids/Neopentane.json
+++ b/dev/fluids/Neopentane.json
@@ -240,6 +240,7 @@
       "acentric_units": "-", 
       "dipole_moment": 0.000e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "Monatomic; \"The Properties of Gases and Liquids\" 5th edition, Poling, Prausnitz, and O'Connell.",
       "alpha0": [
         {
           "a1": 0.8702452614, 

--- a/dev/fluids/Nitrogen.json
+++ b/dev/fluids/Nitrogen.json
@@ -259,6 +259,7 @@
       "acentric_units": "-", 
       "dipole_moment": 0.000e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "Monatomic; \"The Properties of Gases and Liquids\" 5th edition, Poling, Prausnitz, and O'Connell.",
       "alpha0": [
         {
           "a1": -12.76952708, 

--- a/dev/fluids/NitrousOxide.json
+++ b/dev/fluids/NitrousOxide.json
@@ -238,8 +238,9 @@
       "Ttriple_units": "K", 
       "acentric": 0.1613, 
       "acentric_units": "-", 
-      "dipole_moment": 2.000e+00,  
+      "dipole_moment": 0.167,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "NSRDS-NBS10; https://nvlpubs.nist.gov/nistpubs/Legacy/NSRDS/nbsnsrds10.pdf",
       "alpha0": [
         {
           "a1": -4.4262736272, 

--- a/dev/fluids/Novec649.json
+++ b/dev/fluids/Novec649.json
@@ -129,8 +129,9 @@
       "Ttriple_units": "K", 
       "acentric": 0.4710235935799747, 
       "acentric_units": "-", 
-      "dipole_moment": 3.601e-01,  
+      "dipole_moment": 0.36,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "http://www.ethermo.us/ShowDetail2815.htm",
       "alpha0": [
         {
           "a1": -30.6610503233, 

--- a/dev/fluids/OrthoDeuterium.json
+++ b/dev/fluids/OrthoDeuterium.json
@@ -227,8 +227,9 @@
       "Ttriple_units": "K", 
       "acentric": -0.136290274128, 
       "acentric_units": "-", 
-      "dipole_moment":  -1,  
+      "dipole_moment":  0,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "Monatomic; n/a",
       "alpha0": [
         {
           "a1": -2.0672670563, 

--- a/dev/fluids/OrthoHydrogen.json
+++ b/dev/fluids/OrthoHydrogen.json
@@ -229,6 +229,7 @@
       "acentric_units": "-", 
       "dipole_moment": 0.000e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "Monatomic; http://www.ethermo.us/ShowDetail107.htm",
       "alpha0": [
         {
           "a1": -1.4675442336, 

--- a/dev/fluids/Oxygen.json
+++ b/dev/fluids/Oxygen.json
@@ -255,6 +255,7 @@
       "acentric_units": "-", 
       "dipole_moment": 0.000e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "Monatomic; \"The Properties of Gases and Liquids\" 5th edition, Poling, Prausnitz, and O'Connell.",
       "alpha0": [
         {
           "a1": 0, 

--- a/dev/fluids/ParaDeuterium.json
+++ b/dev/fluids/ParaDeuterium.json
@@ -227,8 +227,9 @@
       "Ttriple_units": "K", 
       "acentric": -0.136290274128, 
       "acentric_units": "-", 
-      "dipole_moment":  -1,  
+      "dipole_moment":  0,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "Monatomic; n/a",
       "alpha0": [
         {
           "a1": -2.0683998716, 

--- a/dev/fluids/ParaHydrogen.json
+++ b/dev/fluids/ParaHydrogen.json
@@ -263,6 +263,7 @@
       "acentric_units": "-", 
       "dipole_moment": 0.000e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "Monatomic; http://www.ethermo.us/ShowDetail108.htm",
       "alpha0": [
         {
           "a1": -1.4485891134, 

--- a/dev/fluids/Propylene.json
+++ b/dev/fluids/Propylene.json
@@ -262,8 +262,9 @@
       "Ttriple_units": "K", 
       "acentric": 0.146, 
       "acentric_units": "-", 
-      "dipole_moment": 3.999e-01,  
+      "dipole_moment": 0.366,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "http://www.ethermo.us/ShowDetail109.htm & NSRDS-NBS10: https://nvlpubs.nist.gov/nistpubs/Legacy/NSRDS/nbsnsrds10.pdf",
       "alpha0": [
         {
           "a1": 4.9916462, 

--- a/dev/fluids/Propyne.json
+++ b/dev/fluids/Propyne.json
@@ -240,6 +240,7 @@
       "acentric_units": "-", 
       "dipole_moment": 7.810e-01,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "http://www.ethermo.us/ShowDetail110.htm & NSRDS-NBS10; https://nvlpubs.nist.gov/nistpubs/Legacy/NSRDS/nbsnsrds10.pdf",
       "alpha0": [
         {
           "a1": 0, 

--- a/dev/fluids/R11.json
+++ b/dev/fluids/R11.json
@@ -240,6 +240,7 @@
       "acentric_units": "-", 
       "dipole_moment": 5.001e-01,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "\"The Properties of Gases and Liquids\" 5th edition, Poling, Prausnitz, and O'Connell.",
       "alpha0": [
         {
           "a1": 0, 
@@ -486,6 +487,7 @@
       "acentric_units": "-", 
       "dipole_moment": 5.001e-01,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "\"The Properties of Gases and Liquids\" 5th edition, Poling, Prausnitz, and O'Connell.",
       "alpha0": [
         {
           "a1": 0, 

--- a/dev/fluids/R113.json
+++ b/dev/fluids/R113.json
@@ -238,8 +238,9 @@
       "Ttriple_units": "K", 
       "acentric": 0.252535, 
       "acentric_units": "-", 
-      "dipole_moment": 8.031e-01,  
+      "dipole_moment": 8.03e-01,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "http://www.ethermo.us/ShowDetail40.htm",
       "alpha0": [
         {
           "a1": 13.1479282, 

--- a/dev/fluids/R114.json
+++ b/dev/fluids/R114.json
@@ -240,6 +240,7 @@
       "acentric_units": "-", 
       "dipole_moment": 6.580e-01,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "http://www.ethermo.us/ShowDetail40.htm",
       "alpha0": [
         {
           "a1": 0, 

--- a/dev/fluids/R115.json
+++ b/dev/fluids/R115.json
@@ -135,8 +135,9 @@
       "Ttriple_units": "K", 
       "acentric": 0.24843499306634587, 
       "acentric_units": "-", 
-      "dipole_moment": 5.201e-01,  
+      "dipole_moment": 5.20e-01,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "http://www.ethermo.us/ShowDetail42.htm",
       "alpha0": [
         {
           "a1": 0, 

--- a/dev/fluids/R116.json
+++ b/dev/fluids/R116.json
@@ -242,6 +242,7 @@
       "acentric_units": "-", 
       "dipole_moment": 0.000e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "http://www.ethermo.us/ShowDetail43.htm",
       "alpha0": [
         {
           "a1": -10.7088650331, 

--- a/dev/fluids/R12.json
+++ b/dev/fluids/R12.json
@@ -242,6 +242,7 @@
       "acentric_units": "-", 
       "dipole_moment": 5.001e-01,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "\"The Properties of Gases and Liquids\" 5th edition, Poling, Prausnitz, and O'Connell.",
       "alpha0": [
         {
           "a1": 10.0100905, 

--- a/dev/fluids/R123.json
+++ b/dev/fluids/R123.json
@@ -240,6 +240,7 @@
       "acentric_units": "-", 
       "dipole_moment": 1.356e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "http://www.ethermo.us/ShowDetail44.htm",
       "alpha0": [
         {
           "a1": 0, 
@@ -519,6 +520,7 @@
       "acentric_units": "-", 
       "dipole_moment": 1.356e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "http://www.ethermo.us/ShowDetail44.htm",
       "alpha0": [
         {
           "a1": 0, 

--- a/dev/fluids/R1233zd(E).json
+++ b/dev/fluids/R1233zd(E).json
@@ -240,6 +240,7 @@
       "acentric_units": "-", 
       "dipole_moment": 1.440e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "http://www.ethermo.us/ShowDetail2820.htm",
       "alpha0": [
         {
           "a1": 0, 

--- a/dev/fluids/R1234yf.json
+++ b/dev/fluids/R1234yf.json
@@ -238,8 +238,9 @@
       "Ttriple_units": "K", 
       "acentric": 0.276, 
       "acentric_units": "-", 
-      "dipole_moment":  -1,  
+      "dipole_moment":  2.48,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "https://nvlpubs.nist.gov/nistpubs/jres/117/jres.117.014.pdf",
       "alpha0": [
         {
           "a1": -12.837928, 

--- a/dev/fluids/R1234ze(E).json
+++ b/dev/fluids/R1234ze(E).json
@@ -240,8 +240,9 @@
       "Ttriple_units": "K", 
       "acentric": 0.313, 
       "acentric_units": "-", 
-      "dipole_moment":  -1,  
+      "dipole_moment":  1.27,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "https://nvlpubs.nist.gov/nistpubs/jres/117/jres.117.014.pdf",
       "alpha0": [
         {
           "a1": 0, 
@@ -460,8 +461,9 @@
       "Ttriple_units": "K", 
       "acentric": 0.313, 
       "acentric_units": "-", 
-      "dipole_moment":  -1,  
+      "dipole_moment":  1.27,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "https://nvlpubs.nist.gov/nistpubs/jres/117/jres.117.014.pdf",
       "alpha0": [
         {
           "a1": 0, 

--- a/dev/fluids/R1234ze(Z).json
+++ b/dev/fluids/R1234ze(Z).json
@@ -240,6 +240,7 @@
       "acentric_units": "-", 
       "dipole_moment":  -1,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "No known reference",
       "alpha0": [
         {
           "a1": 0, 

--- a/dev/fluids/R124.json
+++ b/dev/fluids/R124.json
@@ -240,6 +240,7 @@
       "acentric_units": "-", 
       "dipole_moment": 1.469e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "http://www.ethermo.us/ShowDetail45.htm",
       "alpha0": [
         {
           "a1": -11.669406, 

--- a/dev/fluids/R125.json
+++ b/dev/fluids/R125.json
@@ -240,6 +240,7 @@
       "acentric_units": "-", 
       "dipole_moment": 1.563e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "http://www.ethermo.us/ShowDetail46.htm",
       "alpha0": [
         {
           "a1": 37.2674, 

--- a/dev/fluids/R13.json
+++ b/dev/fluids/R13.json
@@ -240,6 +240,7 @@
       "acentric_units": "-", 
       "dipole_moment": 5.099e-01,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "\"The Properties of Gases and Liquids\" 5th edition, Poling, Prausnitz, and O'Connell.",
       "alpha0": [
         {
           "a1": 0, 

--- a/dev/fluids/R134a.json
+++ b/dev/fluids/R134a.json
@@ -240,6 +240,7 @@
       "acentric_units": "-", 
       "dipole_moment": 2.058e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "http://www.ethermo.us/ShowDetail47.htm",
       "alpha0": [
         {
           "a1": -1.019535, 

--- a/dev/fluids/R13I1.json
+++ b/dev/fluids/R13I1.json
@@ -135,8 +135,9 @@
       "Ttriple_units": "K", 
       "acentric": 0.17618111777018552, 
       "acentric_units": "-", 
-      "dipole_moment": 9.201e-01,  
+      "dipole_moment": 9.20e-01,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "http://www.ethermo.us/ShowDetail30.htm",
       "alpha0": [
         {
           "a1": 0, 

--- a/dev/fluids/R14.json
+++ b/dev/fluids/R14.json
@@ -240,6 +240,7 @@
       "acentric_units": "-", 
       "dipole_moment": 0.000e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "http://www.ethermo.us/ShowDetail34.htm",
       "alpha0": [
         {
           "a1": 0, 

--- a/dev/fluids/R141b.json
+++ b/dev/fluids/R141b.json
@@ -242,6 +242,7 @@
       "acentric_units": "-", 
       "dipole_moment": 2.014e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "http://www.ethermo.us/ShowDetail48.htm",
       "alpha0": [
         {
           "a1": -15.5074814985, 

--- a/dev/fluids/R142b.json
+++ b/dev/fluids/R142b.json
@@ -240,6 +240,7 @@
       "acentric_units": "-", 
       "dipole_moment": 2.140e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "http://www.ethermo.us/ShowDetail49.htm",
       "alpha0": [
         {
           "a1": -12.6016527149, 

--- a/dev/fluids/R143a.json
+++ b/dev/fluids/R143a.json
@@ -240,6 +240,7 @@
       "acentric_units": "-", 
       "dipole_moment": 2.340e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "http://www.ethermo.us/ShowDetail50.htm",
       "alpha0": [
         {
           "a1": 5.903087, 

--- a/dev/fluids/R152A.json
+++ b/dev/fluids/R152A.json
@@ -240,6 +240,7 @@
       "acentric_units": "-", 
       "dipole_moment": 2.262e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "http://www.ethermo.us/ShowDetail51.htm",
       "alpha0": [
         {
           "a1": 0, 
@@ -515,6 +516,7 @@
       "acentric_units": "-", 
       "dipole_moment": 2.262e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "http://www.ethermo.us/ShowDetail51.htm",
       "alpha0": [
         {
           "a1": 10.87227, 

--- a/dev/fluids/R161.json
+++ b/dev/fluids/R161.json
@@ -238,8 +238,9 @@
       "Ttriple_units": "K", 
       "acentric": 0.2162428410661867, 
       "acentric_units": "-", 
-      "dipole_moment": 1.940e+00,  
+      "dipole_moment": 1.9397e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "http://www.ethermo.us/ShowDetail111.htm",
       "alpha0": [
         {
           "a1": -6.9187, 

--- a/dev/fluids/R21.json
+++ b/dev/fluids/R21.json
@@ -240,6 +240,7 @@
       "acentric_units": "-", 
       "dipole_moment": 1.370e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "http://www.ethermo.us/ShowDetail35.htm",
       "alpha0": [
         {
           "a1": 0, 

--- a/dev/fluids/R218.json
+++ b/dev/fluids/R218.json
@@ -240,6 +240,7 @@
       "acentric_units": "-", 
       "dipole_moment": 1.400e-01,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "http://www.ethermo.us/ShowDetail52.htm",
       "alpha0": [
         {
           "a1": -15.6587335175, 

--- a/dev/fluids/R22.json
+++ b/dev/fluids/R22.json
@@ -242,6 +242,7 @@
       "acentric_units": "-", 
       "dipole_moment": 1.458e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "http://www.ethermo.us/ShowDetail36.htm",
       "alpha0": [
         {
           "a1": -15.86079407387002, 

--- a/dev/fluids/R227EA.json
+++ b/dev/fluids/R227EA.json
@@ -244,6 +244,7 @@
       "acentric_units": "-", 
       "dipole_moment": 1.456e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "http://www.ethermo.us/ShowDetail53.htm",
       "alpha0": [
         {
           "a1": -15.8291124137, 

--- a/dev/fluids/R23.json
+++ b/dev/fluids/R23.json
@@ -242,6 +242,7 @@
       "acentric_units": "-", 
       "dipole_moment": 1.649e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "http://www.ethermo.us/ShowDetail37.htm",
       "alpha0": [
         {
           "a1": -8.31386064, 

--- a/dev/fluids/R236EA.json
+++ b/dev/fluids/R236EA.json
@@ -242,6 +242,7 @@
       "acentric_units": "-", 
       "dipole_moment": 1.129e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "http://www.ethermo.us/ShowDetail54.htm",
       "alpha0": [
         {
           "a1": -14.121424135, 

--- a/dev/fluids/R236FA.json
+++ b/dev/fluids/R236FA.json
@@ -240,6 +240,7 @@
       "acentric_units": "-", 
       "dipole_moment": 1.982e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "http://www.ethermo.us/ShowDetail55.htm",
       "alpha0": [
         {
           "a1": -17.5983849, 

--- a/dev/fluids/R245ca.json
+++ b/dev/fluids/R245ca.json
@@ -146,6 +146,7 @@
       "acentric_units": "-", 
       "dipole_moment": 1.740e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "http://www.ethermo.us/ShowDetail56.htm",
       "alpha0": [
         {
           "a1": -18.09410031, 

--- a/dev/fluids/R245fa.json
+++ b/dev/fluids/R245fa.json
@@ -244,6 +244,7 @@
       "acentric_units": "-", 
       "dipole_moment": 1.549e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "http://www.ethermo.us/ShowDetail57.htm",
       "alpha0": [
         {
           "a1": -13.4283638514, 
@@ -446,6 +447,7 @@
       "acentric_units": "-", 
       "dipole_moment": 1.549e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "http://www.ethermo.us/ShowDetail57.htm",
       "alpha0": [
         {
           "a1": -13.4283638514, 

--- a/dev/fluids/R32.json
+++ b/dev/fluids/R32.json
@@ -240,6 +240,7 @@
       "acentric_units": "-", 
       "dipole_moment": 1.978e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "http://www.ethermo.us/ShowDetail38.htm",
       "alpha0": [
         {
           "a1": -8.258096, 

--- a/dev/fluids/R365MFC.json
+++ b/dev/fluids/R365MFC.json
@@ -240,6 +240,7 @@
       "acentric_units": "-", 
       "dipole_moment":  -1,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "No Reference Found",
       "alpha0": [
         {
           "a1": -16.3423704513, 

--- a/dev/fluids/R40.json
+++ b/dev/fluids/R40.json
@@ -150,6 +150,7 @@
       "acentric_units": "-", 
       "dipole_moment": 1.871e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "http://www.ethermo.us/ShowDetail2818.htm",
       "alpha0": [
         {
           "a1": 7.499423, 

--- a/dev/fluids/R404A.json
+++ b/dev/fluids/R404A.json
@@ -282,6 +282,7 @@
       "acentric_units": "-", 
       "dipole_moment":  -1,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "Undefined for Mixtures",
       "alpha0": [
         {
           "a1": 7.00407, 

--- a/dev/fluids/R407C.json
+++ b/dev/fluids/R407C.json
@@ -282,6 +282,7 @@
       "acentric_units": "-", 
       "dipole_moment":  -1,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "Undefined for Mixtures",
       "alpha0": [
         {
           "a1": 2.13194, 

--- a/dev/fluids/R41.json
+++ b/dev/fluids/R41.json
@@ -240,6 +240,7 @@
       "acentric_units": "-", 
       "dipole_moment": 1.851e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "http://www.ethermo.us/ShowDetail39.htm",
       "alpha0": [
         {
           "a1": -4.867644116, 

--- a/dev/fluids/R410A.json
+++ b/dev/fluids/R410A.json
@@ -282,6 +282,7 @@
       "acentric_units": "-", 
       "dipole_moment":  -1,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "Undefined for Mixtures",
       "alpha0": [
         {
           "a1": 36.8871, 

--- a/dev/fluids/R507A.json
+++ b/dev/fluids/R507A.json
@@ -282,6 +282,7 @@
       "acentric_units": "-", 
       "dipole_moment":  -1,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "Undefined for Mixtures",
       "alpha0": [
         {
           "a1": 9.93541, 

--- a/dev/fluids/RC318.json
+++ b/dev/fluids/RC318.json
@@ -240,6 +240,7 @@
       "acentric_units": "-", 
       "dipole_moment": 0.000e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "http://www.ethermo.us/ShowDetail59.htm",
       "alpha0": [
         {
           "a1": 0, 

--- a/dev/fluids/SES36.json
+++ b/dev/fluids/SES36.json
@@ -279,6 +279,7 @@
       "acentric_units": "-", 
       "dipole_moment":  -1,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "Undefined for mixtures; Mixture of R365mfc (1,1,1,3,3-Pentafluorobutane) and Galden HT 55 (Perfluoropolyether)",
       "alpha0": [
         {
           "a1": 0, 

--- a/dev/fluids/SulfurDioxide.json
+++ b/dev/fluids/SulfurDioxide.json
@@ -238,8 +238,9 @@
       "Ttriple_units": "K", 
       "acentric": 0.2561299361987246, 
       "acentric_units": "-", 
-      "dipole_moment": 1.600e+00,  
+      "dipole_moment": 1.60e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "http://www.ethermo.us/ShowDetail22.htm",
       "alpha0": [
         {
           "a1": -4.5414235721, 
@@ -450,8 +451,9 @@
       "Ttriple_units": "K", 
       "acentric": 0.2557, 
       "acentric_units": "-", 
-      "dipole_moment": 1.600e+00,  
+      "dipole_moment": 1.60e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "http://www.ethermo.us/ShowDetail22.htm",
       "alpha0": [
         {
           "a1": -4.5328346436, 

--- a/dev/fluids/SulfurHexafluoride.json
+++ b/dev/fluids/SulfurHexafluoride.json
@@ -242,6 +242,7 @@
       "acentric_units": "-", 
       "dipole_moment": 0.000e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "http://www.ethermo.us/ShowDetail23.htm",
       "alpha0": [
         {
           "a1": 11.638611086, 

--- a/dev/fluids/Toluene.json
+++ b/dev/fluids/Toluene.json
@@ -238,8 +238,9 @@
       "Ttriple_units": "K", 
       "acentric": 0.2657, 
       "acentric_units": "-", 
-      "dipole_moment": 3.601e-01,  
+      "dipole_moment": 3.60e-01,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "http://www.ethermo.us/ShowDetail23.htm; https://nvlpubs.nist.gov/nistpubs/Legacy/NSRDS/nbsnsrds10.pdf",
       "alpha0": [
         {
           "a1": 3.5241174832, 

--- a/dev/fluids/Water.json
+++ b/dev/fluids/Water.json
@@ -301,6 +301,7 @@
       "acentric_units": "-", 
       "dipole_moment": 1.855e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "http://www.ethermo.us/ShowDetail1.htm; https://cccbdb.nist.gov/diplistx.asp",
       "alpha0": [
         {
           "a1": -8.3204464837497, 

--- a/dev/fluids/Xenon.json
+++ b/dev/fluids/Xenon.json
@@ -242,6 +242,7 @@
       "acentric_units": "-", 
       "dipole_moment": 0.000e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "Monatomic; http://www.ethermo.us/ShowDetail14.htm",
       "alpha0": [
         {
           "a1": -3.8227178129, 

--- a/dev/fluids/cis-2-Butene.json
+++ b/dev/fluids/cis-2-Butene.json
@@ -240,7 +240,8 @@
       "acentric_units": "-", 
       "dipole_moment": 3.001e-01,  
       "dipole_moment_units": "Debye",  
-      "alpha0": [
+      "dipole_moment_ref": "\"The Properties of Gases and Liquids\" 5th edition, Poling, Prausnitz, and O'Connell.",
+            "alpha0": [
         {
           "a1": 0.2591542, 
           "a2": 2.4189888, 

--- a/dev/fluids/m-Xylene.json
+++ b/dev/fluids/m-Xylene.json
@@ -238,8 +238,9 @@
       "Ttriple_units": "K", 
       "acentric": 0.326, 
       "acentric_units": "-", 
-      "dipole_moment": 3.001e-01,  
+      "dipole_moment": 3.0e-01,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "http://www.ethermo.us/ShowDetail2814.htm",
       "alpha0": [
         {
           "a1": 12.652887, 

--- a/dev/fluids/n-Butane.json
+++ b/dev/fluids/n-Butane.json
@@ -257,8 +257,9 @@
       "Ttriple_units": "K", 
       "acentric": 0.200810094644, 
       "acentric_units": "-", 
-      "dipole_moment": 2.004e-01,  
+      "dipole_moment": 0.05,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "NSRDS-NBS10; https://nvlpubs.nist.gov/nistpubs/Legacy/NSRDS/nbsnsrds10.pdf",
       "alpha0": [
         {
           "a1": 12.54882924, 

--- a/dev/fluids/n-Decane.json
+++ b/dev/fluids/n-Decane.json
@@ -238,8 +238,9 @@
       "Ttriple_units": "K", 
       "acentric": 0.4884, 
       "acentric_units": "-", 
-      "dipole_moment": 4.881e-01,  
+      "dipole_moment": 0.07,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "http://www.stenutz.eu/chem/solv6.php?name=decane",
       "alpha0": [
         {
           "a1": 13.9361966549, 

--- a/dev/fluids/n-Dodecane.json
+++ b/dev/fluids/n-Dodecane.json
@@ -240,8 +240,9 @@
       "Ttriple_units": "K", 
       "acentric": 0.574182221240689, 
       "acentric_units": "-", 
-      "dipole_moment": 5.699e-01,  
+      "dipole_moment": 0.07,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "http://www.stenutz.eu/chem/solv6.php?name=dodecane",
       "alpha0": [
         {
           "a1": 0, 

--- a/dev/fluids/n-Heptane.json
+++ b/dev/fluids/n-Heptane.json
@@ -240,8 +240,9 @@
       "Ttriple_units": "K", 
       "acentric": 0.349, 
       "acentric_units": "-", 
-      "dipole_moment": 7.000e-02,  
+      "dipole_moment": 0.07,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "http://www.ethermo.us/ShowDetail69.htm",
       "alpha0": [
         {
           "a1": -1.599437140443368, 

--- a/dev/fluids/n-Hexane.json
+++ b/dev/fluids/n-Hexane.json
@@ -240,8 +240,9 @@
       "Ttriple_units": "K", 
       "acentric": 0.299, 
       "acentric_units": "-", 
-      "dipole_moment": 2.978e-01,  
+      "dipole_moment": 0.08,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "http://www.stenutz.eu/chem/solv6.php?name=hexane; http://www.substech.com/dokuwiki/doku.php?id=hexane",
       "alpha0": [
         {
           "a1": -1.570859897210351, 

--- a/dev/fluids/n-Nonane.json
+++ b/dev/fluids/n-Nonane.json
@@ -238,8 +238,9 @@
       "Ttriple_units": "K", 
       "acentric": 0.4433, 
       "acentric_units": "-", 
-      "dipole_moment": 4.449e-01,  
+      "dipole_moment": 0.07,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "http://www.stenutz.eu/chem/solv6.php?name=nonane",
       "alpha0": [
         {
           "a1": 10.7927224829, 

--- a/dev/fluids/n-Octane.json
+++ b/dev/fluids/n-Octane.json
@@ -244,6 +244,7 @@
       "acentric_units": "-", 
       "dipole_moment": 7.000e-02,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "http://www.ethermo.us/ShowDetail63.htm",
       "alpha0": [
         {
           "a1": -1.601873998562896, 

--- a/dev/fluids/n-Pentane.json
+++ b/dev/fluids/n-Pentane.json
@@ -258,8 +258,9 @@
       "Ttriple_units": "K", 
       "acentric": 0.251, 
       "acentric_units": "-", 
-      "dipole_moment": 2.511e-01,  
+      "dipole_moment": 0.07,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "http://www.ethermo.us/ShowDetail64.htm; NSRDS-NBS10 reports < 0.1: https://nvlpubs.nist.gov/nistpubs/Legacy/NSRDS/nbsnsrds10.pdf",
       "alpha0": [
         {
           "a1": -1.548185641277708, 

--- a/dev/fluids/n-Propane.json
+++ b/dev/fluids/n-Propane.json
@@ -255,8 +255,9 @@
       "Ttriple_units": "K", 
       "acentric": 0.1521, 
       "acentric_units": "-", 
-      "dipole_moment": 1.524e-01,  
+      "dipole_moment": 0.083,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "J. Chem. Phys. 33, 1514 (1960); https://doi.org/10.1063/1.1731434",
       "alpha0": [
         {
           "a1": -4.970583, 

--- a/dev/fluids/n-Undecane.json
+++ b/dev/fluids/n-Undecane.json
@@ -238,8 +238,9 @@
       "Ttriple_units": "K", 
       "acentric": 0.5390371013718567, 
       "acentric_units": "-", 
-      "dipole_moment": 5.300e-01,  
+      "dipole_moment": 0.00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "http://www.ethermo.us/ShowDetail2809.htm",
       "alpha0": [
         {
           "a1": 0, 

--- a/dev/fluids/o-Xylene.json
+++ b/dev/fluids/o-Xylene.json
@@ -238,8 +238,9 @@
       "Ttriple_units": "K", 
       "acentric": 0.312, 
       "acentric_units": "-", 
-      "dipole_moment": 6.299e-01,  
+      "dipole_moment": 0.63,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "http://www.ethermo.us/ShowDetail2816.htm",
       "alpha0": [
         {
           "a1": 10.137376, 

--- a/dev/fluids/p-Xylene.json
+++ b/dev/fluids/p-Xylene.json
@@ -240,6 +240,7 @@
       "acentric_units": "-", 
       "dipole_moment": 0.000e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "http://www.ethermo.us/ShowDetail2817.htm",
       "alpha0": [
         {
           "a1": 5.9815241, 

--- a/dev/fluids/trans-2-Butene.json
+++ b/dev/fluids/trans-2-Butene.json
@@ -242,6 +242,7 @@
       "acentric_units": "-", 
       "dipole_moment": 0.000e+00,  
       "dipole_moment_units": "Debye",  
+      "dipole_moment_ref": "Symmetric molecule; http://www.ethermo.us/ShowDetail114.htm",
       "alpha0": [
         {
           "a1": 0.5917816, 


### PR DESCRIPTION
### Description of the Change

1. Added the source references from your original commits to the "dipole_moment_ref" field in each of the fluid JSON files.
2. Fixed some minor precision issues with some of the values.  There were some extra digits that weren't in the source reference.  These were probably rounding residue from the conversion to C*m and back to Debye units.  Sorry for that unnecessary iteration.
3. Figured out the issue with the Alkanes.  Back when these were originally committed, I checked the JSON values against eThermo and they indeed had the values posted online.  Checking this week they have changed!  The values posted were actually the acentric factor and they are now labelled as such on the eThermo site.  New values that much more closely match the REFPROP values are now posted for dipole moment for all the normal alkanes.
4. Found a source reference for a few refrigerants that were in REFPROP but missing from CoolProp.

### Benefits

Keeps track of where the dipole moment values come from.

### Verification Process

- [x] Compiled and ran CoolProp with the new JSON files and all fluids load successfully and report dipole moment values.
- [x] Generated a new comparison csv file between the new CoolProp values and the values reported from REFPROP, listing the % difference between the two.  This csv will be posted in the comments on your original PR to CoolProp/CoolProp.

