### PR TITLE
Fixed precision issues for fluid dipole moment reference values

### DIFF
--- a/dev/fluids/D4.json
+++ b/dev/fluids/D4.json
@@ -238,7 +238,7 @@
       "Ttriple_units": "K", 
       "acentric": 0.5981248267987835, 
       "acentric_units": "-", 
-      "dipole_moment": 1.091e+00,  
+      "dipole_moment": 1.09e+00,  
       "dipole_moment_units": "Debye",  
       "dipole_moment_ref": "https://www.gelest.com/product/octamethylcyclotetrasiloxane-98/",
       "alpha0": [
@@ -438,7 +438,7 @@
       "Ttriple_units": "K", 
       "acentric": 0.592, 
       "acentric_units": "-", 
-      "dipole_moment": 1.091e+00,  
+      "dipole_moment": 1.09e+00,  
       "dipole_moment_units": "Debye",  
       "dipole_moment_ref": "https://www.gelest.com/product/octamethylcyclotetrasiloxane-98/",
       "alpha0": [

--- a/dev/fluids/IsoButene.json
+++ b/dev/fluids/IsoButene.json
@@ -238,7 +238,7 @@
       "Ttriple_units": "K", 
       "acentric": 0.1925934521621, 
       "acentric_units": "-", 
-      "dipole_moment": 5.001e-01,  
+      "dipole_moment": 5.0e-01,  
       "dipole_moment_units": "Debye",  
       "dipole_moment_ref": "\"The Properties of Gases and Liquids\" 5th edition, Poling, Prausnitz, and O'Connell.",
       "alpha0": [

--- a/dev/fluids/R13.json
+++ b/dev/fluids/R13.json
@@ -238,7 +238,7 @@
       "Ttriple_units": "K", 
       "acentric": 0.174586327798, 
       "acentric_units": "-", 
-      "dipole_moment": 5.099e-01,  
+      "dipole_moment": 5.0e-01,  
       "dipole_moment_units": "Debye",  
       "dipole_moment_ref": "\"The Properties of Gases and Liquids\" 5th edition, Poling, Prausnitz, and O'Connell.",
       "alpha0": [

--- a/dev/fluids/cis-2-Butene.json
+++ b/dev/fluids/cis-2-Butene.json
@@ -238,7 +238,7 @@
       "Ttriple_units": "K", 
       "acentric": 0.20235958587, 
       "acentric_units": "-", 
-      "dipole_moment": 3.001e-01,  
+      "dipole_moment": 3.00e-01,  
       "dipole_moment_units": "Debye",  
       "dipole_moment_ref": "\"The Properties of Gases and Liquids\" 5th edition, Poling, Prausnitz, and O'Connell.",
             "alpha0": [


### PR DESCRIPTION
### Description of the Change

Found a copy of Poling, 5th Edition.  Fixed a few fluid values that did not agree with the reference values in the last decimal place.  Poling rounds all dipole moments to the nearest 0.1.  One similar value corrected that did not exactly agree with the Geleste commercial site value.  Fluids modified:
        modified:   dev/fluids/D4.json
        modified:   dev/fluids/IsoButene.json
        modified:   dev/fluids/R13.json
        modified:   dev/fluids/cis-2-Butene.json

### Benefits

While these values were close, but did not exactly agree with reference value.

### Verification Process

Verified values against Poling, 5th Ed. and referenced Geleste site reference.
